### PR TITLE
Fixes linking issues with construction of logs

### DIFF
--- a/app/src/main/java/ci/FileIO.java
+++ b/app/src/main/java/ci/FileIO.java
@@ -26,7 +26,7 @@ public class FileIO {
      * 
      * @param sha The SHA code for the commit
      * @param buildLog The build log for the commit
-     * @param filepath Path to the folder where the logs are stored
+     * @param filepath Path to the parent folder where the logs are stored
      * @param link The http-link to the github repo
      *             Format: "https://github.com/[organisation]]/[repo]"
      */

--- a/app/src/main/java/ci/FileIO.java
+++ b/app/src/main/java/ci/FileIO.java
@@ -152,7 +152,7 @@ public class FileIO {
         
         for(int i = pathnames.length-1; i >= 0; i--){
             File pathname = pathnames[i];
-            String url = pathname.toString();
+            String url = pathname.getAbsolutePath();
             BasicFileAttributes attr = Files.readAttributes(Paths.get(url), BasicFileAttributes.class);
             String linkText = attr.creationTime().toString();
             sb.append("<a href='" + url + "'>" + linkText + "</a></br>");

--- a/app/src/main/java/ci/FileIO.java
+++ b/app/src/main/java/ci/FileIO.java
@@ -28,19 +28,30 @@ public class FileIO {
      * @param buildLog The build log for the commit
      * @param filepath Path to the folder where the logs are stored
      * @param link The http-link to the github repo
-     *             Format: "https://github.com/[organisation]]/[repo]]/commit/"
-     *             '/commit/' can be changed to '/tree/' depending on what you want to display
+     *             Format: "https://github.com/[organisation]]/[repo]"
      */
     public static void constructLog(String sha, String buildLog, String filepath, String link){
-        // Check that folder exists and how many files it contains
+        // Check that folder exists, this will hold index.html and a subfolder for the buildlogs
         File[] pathnames = listFileNames(filepath);
+        if(pathnames == null){
+            try{
+                createFolder(filepath);
+            }catch(InvalidObjectException e){
+                System.out.println("ConstructLog exception: createFolder 1: " + e);
+            }
+        }
+
+        // The build logs are stored in a subfolder called buildLogs
+        String buildLogPath = filepath + "buildLogs/";
+        pathnames = listFileNames(buildLogPath);
+        //Check if the buildLogs subfolder exist, if not - create it, then count the amount of logs in it
         int nameOffset = 0;
         if(pathnames == null){
             //folder does not exist, create it
             try{
-                createFolder(filepath);
+                createFolder(buildLogPath);
             }catch(InvalidObjectException e){
-                System.out.println("constructLog exception: createFolder: " + e);
+                System.out.println("constructLog exception: createFolder 2: " + e);
                 System.exit(0);
             }
         }else{
@@ -48,21 +59,22 @@ public class FileIO {
         }
         
         // Create the HTML file that represents this build
+        // It links to the commit on github by its sha and link to repo
         String logHTML = createLogHTML(sha, buildLog, link);
         int fileNumber = nameOffset + 1;
         String filename = fileNumber + ".html";
         try{
-            writeToFile(filename,logHTML,filepath);
+            writeToFile(filename,logHTML,buildLogPath);
         }catch(IOException e){
             System.out.println("constructLog exception: writeToFile: " + e);
             System.exit(0);
         }
 
         // Takes the content of filepath and construct the index file
-        pathnames = listFileNames(filepath);
+        pathnames = listFileNames(buildLogPath);
         try {
             String indexHTML = createIndexHTML(pathnames);
-            writeToFile("index.html", indexHTML, "");
+            writeToFile("index.html", indexHTML, filepath);
         } catch(IOException e){
             System.out.println("constructLog exception: createIndexHTML: " + e);
             System.exit(0);

--- a/app/src/main/java/ci/FileIO.java
+++ b/app/src/main/java/ci/FileIO.java
@@ -162,6 +162,7 @@ public class FileIO {
         
         sb.append("<!DOCTYPE html><html><head><title>Index</title></head><body>");
         
+        // Iterates from the top down so that the newest build is shown at top
         for(int i = pathnames.length-1; i >= 0; i--){
             File pathname = pathnames[i];
             String url = pathname.getAbsolutePath();

--- a/app/src/main/java/ci/FileIO.java
+++ b/app/src/main/java/ci/FileIO.java
@@ -122,7 +122,7 @@ public class FileIO {
     }
 
 
-     /**
+     /** Create the html file as a String representation that represent the build log by adding a link to the github commit showing the build log
      * 
      * @param sha SHA code for the github commit
      * @param buildLog The buildlog for the commit
@@ -132,12 +132,12 @@ public class FileIO {
         StringBuilder sb = new StringBuilder();
         
         sb.append("<!DOCTYPE html><html><head><title>Index</title></head><body>");
-        sb.append("<a href='" + link + sha  + "'>Github Commit</a></br>");
+        sb.append("<a href='" + link + "/commit/" + sha  + "'>Github Commit</a></br>");
         sb.append(buildLog);
         sb.append("</body></html>");
 
         return sb.toString();
-    }   
+    }     
 
     /** Creates a top level index file that is populated with links to the log files
      * 


### PR DESCRIPTION
This fixes the issues with incorrect links constructed by constructLog by changing how the directory is built. Now the user specifies where he wants to store the logs, and the index-file is created there and instead the logs are placed in a subdirectory of that folder, making everything be in the same place.

resolve #30 